### PR TITLE
Fix login password and show lyrics line by line

### DIFF
--- a/app.py
+++ b/app.py
@@ -13,7 +13,7 @@ st.set_page_config(
 
 # Authentication constants
 AUTH_EMAIL = "ahkaur77@gmail.com"
-AUTH_PASSWORD = "Arsh2024"
+AUTH_PASSWORD = "Arsh2004"
 
 # Song data
 RELEASE_TIME = datetime.datetime(2024, 12, 1, 18, 0, tzinfo=ZoneInfo("America/Toronto"))
@@ -105,7 +105,8 @@ def home_page():
     if now >= RELEASE_TIME:
         st.balloons()
         st.audio(str(SONG_FILE), format="audio/mp3")
-        st.markdown(SONG_LYRICS)
+        lyrics_md = SONG_LYRICS.replace("\n", "  \n")
+        st.markdown(lyrics_md)
 
 
 def main():


### PR DESCRIPTION
## Summary
- Update birthday song app password to `Arsh2004`
- Render lyrics with markdown line breaks so each line shows separately

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_689f5f5874e883288355625f7dc9057d