### PR TITLE
feat: add playful password hint

### DIFF
--- a/app.py
+++ b/app.py
@@ -116,15 +116,20 @@ def login_page():
             "Only the one who knows the secret email and its latest password may pass! ✨ "
             "This gate keeps the surprise safe until you're ready."
         )
-        st.caption(
-            "Hint to her here... That I am stalking you... all the time... I'm kidding... "
-            "BUT Tu apni email da passowrd kiyu change kita, oh v 47 hours before... Kutti... Jeyi... "
-            "You think you are not going to tell, and I will not know... Jeh, tenu apna purana password chettan, tehn use that instead!"
-        )
         with st.form("login_form", clear_on_submit=False):
             email = st.text_input("Email")
             password = st.text_input("Password", type="password")
             submitted = st.form_submit_button("Enter 🎈")
+
+        with st.expander("Don't know what the password is?"):
+            st.caption(
+                "I am stalking you 😈… I KNOW what you are doing 👀… all the time ⏳ (kidding 🤭)… "
+                "BUT tu apni email da password kiyu change kita 😳, oh v 47 hours before ⏰… "
+                "Kutti 😜… Jeyi 😂… You think you’re not going to tell 😏, and I won’t know 🤔? "
+                "Jeh, tenu apna purana password chettan 🧠, tehn use that instead 😉🔑… I KNOW EVERYTHING 🕵️‍♂️… "
+                "BE CAREFUL ⚠️… I’ve installed cameras in your house 🎥👀… so watch out 😏… "
+                "kuch zyada na dekh la main. 🫣📹"
+            )
 
         if submitted:
             if email == AUTH_EMAIL and password == AUTH_PASSWORD:


### PR DESCRIPTION
## Summary
- place a collapsible hint below the login form
- update hint text with playful warning message

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_689f762e21c48328b53618fb7ca568d1